### PR TITLE
pull request for password encoder problems

### DIFF
--- a/client-frontend/src/components/header/Header.jsx
+++ b/client-frontend/src/components/header/Header.jsx
@@ -40,8 +40,8 @@ export default function Header() {
     const [categories, setCategories] = useState([]);
     const [favorites, setFavorites] = useState([])
 
-    const[numberOfCartItems, setNumberOfCartItems] = useState()
-    const[numberOfFavorites, setNumberOfFavorites] = useState()
+    const[numberOfCartItems, setNumberOfCartItems] = useState(0)
+    const[numberOfFavorites, setNumberOfFavorites] = useState(0)
 
     const { isAuthenticated, username } = useAuth();
     const auth = useAuth();
@@ -72,16 +72,13 @@ export default function Header() {
     }
 
     useEffect(() => {
-        getCategoryList()
-    }, []);
-
-    useEffect(() => {
         if(username){
             getFavoritesList()
 
             getNumberOfFavorites()
             getNumberOfCartItems()
         }
+        getCategoryList()
     }, [location, username]);
 
     function getNumberOfCartItems(){
@@ -119,14 +116,16 @@ export default function Header() {
                 <div className="flex md:hidden lg:hidden xl:hidden 2xl:hidden">
                     <Link to='/account/cart' className="relative mr-6">
                         <ShoppingBagIcon className="h-6 w-6 text-gray-900 dark:text-inherit"/>
-                        <div className="absolute
-                             inline-flex items-center justify-center
-                             w-4 h-4
-                             text-xxs font-bold text-white bg-red-500 border-0 border-white rounded-full
-                             -top-2 -right-2
-                             dark:border-gray-900">
-                            {numberOfCartItems}
-                        </div>
+                        {numberOfCartItems!==0 &&
+                            <div className="absolute
+                                 inline-flex items-center justify-center
+                                 w-4 h-4
+                                 text-xxs font-bold text-white bg-red-500 border-0 border-white rounded-full
+                                 -top-2 -right-2
+                                 dark:border-gray-900">
+                                {numberOfCartItems}
+                            </div>
+                        }
                     </Link>
 
                     <button
@@ -210,14 +209,14 @@ export default function Header() {
                 <div className="hidden md:flex md:flex-1 md:justify-end lg:flex lg:flex-1 lg:justify-end xl:flex xl:flex-1 xl:justify-end 2xl:flex 2xl:flex-1 2xl:justify-end text-inherit dark:text-inherit">
 
                     {isAuthenticated &&
-                        <Popover className="relative mr-8 ">
+                        <Popover className="relative mr-6">
                             <Popover.Button onClick={()=> navigate('/account/favorites')}
                                             className="inline-flex items-center gap-x-0 text-sm font-semibold leading-6 text-gray-900 dark:text-inherit"
                                             onMouseEnter={() => setIsShowing(true)}
                                             onMouseLeave={() => setIsShowing(false)}
                             >
                                 <HeartIcon strokeWidth="2" className="h-6 w-6 text-gray-900 dark:text-inherit" aria-disabled="true"/>
-                                {numberOfFavorites &&
+                                {numberOfFavorites!==0 &&
                                     <div className="absolute inline-flex items-center justify-center
                                              w-4 h-4
                                              text-xxs font-bold text-white bg-red-500 border-0 border-white rounded-full
@@ -303,7 +302,7 @@ export default function Header() {
 
                     <Link to='/account/cart' className="inline-flex relative mr-6">
                         <ShoppingBagIcon className="h-6 w-6 text-gray-900 dark:text-inherit"/>
-                        {numberOfCartItems &&
+                        {numberOfCartItems!==0 &&
                             <div className="absolute inline-flex items-center justify-center
                                  w-4 h-4
                                  text-xxs font-bold text-white bg-red-500 border-0 border-white rounded-full

--- a/src/main/java/com/ozius/internship/project/ProjectApplication.java
+++ b/src/main/java/com/ozius/internship/project/ProjectApplication.java
@@ -1,10 +1,7 @@
 package com.ozius.internship.project;
 
-import org.modelmapper.ModelMapper;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class  ProjectApplication {

--- a/src/main/java/com/ozius/internship/project/controller/BuyerController.java
+++ b/src/main/java/com/ozius/internship/project/controller/BuyerController.java
@@ -27,6 +27,10 @@ public class BuyerController {
     public Stream<CartItemDTO> retrieveCartItemsByUserEmail(Principal principal){
         String loggedUserName = principal.getName();
 
+        if(buyerService.getFavoritesByUserEmail(loggedUserName).isEmpty()){
+            return Stream.empty();
+        }
+
         return buyerService.getCartItemsByUserEmail(loggedUserName).stream().map(cartItem -> modelMapper.map(cartItem, CartItemDTO.class));
     }
 

--- a/src/main/java/com/ozius/internship/project/service/BuyerService.java
+++ b/src/main/java/com/ozius/internship/project/service/BuyerService.java
@@ -28,6 +28,10 @@ public class BuyerService {
         long userId = userAccountRepository.findByEmail(email).getId();
         long buyerId = buyerRepository.findBuyerByAccount_Id(userId).getId();
 
+        if(cartRepository.findCartByBuyer_Id(buyerId) == null){
+            return null;
+        }
+
         return cartRepository.findCartByBuyer_Id(buyerId).getCartItems();
     }
 

--- a/src/main/resources/application-localmssql.properties
+++ b/src/main/resources/application-localmssql.properties
@@ -6,4 +6,3 @@ spring.datasource.password=yourStrong(!)Password
 spring.jpa.database-platform=org.hibernate.dialect.SQLServerDialect
 
 spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.generate-ddl=false ?

--- a/src/test/java/com/ozius/internship/project/ProjectApplicationTest.java
+++ b/src/test/java/com/ozius/internship/project/ProjectApplicationTest.java
@@ -2,7 +2,6 @@ package com.ozius.internship.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
 
 @SpringBootApplication
 public class ProjectApplicationTest {

--- a/src/test/java/com/ozius/internship/project/ProjectApplicationWebAppEmbeddedDb.java
+++ b/src/test/java/com/ozius/internship/project/ProjectApplicationWebAppEmbeddedDb.java
@@ -1,9 +1,7 @@
 package com.ozius.internship.project;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class ProjectApplicationWebAppEmbeddedDb {

--- a/src/test/java/com/ozius/internship/project/ProjectApplicationWebAppLocalMssql.java
+++ b/src/test/java/com/ozius/internship/project/ProjectApplicationWebAppLocalMssql.java
@@ -1,9 +1,7 @@
 package com.ozius.internship.project;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class ProjectApplicationWebAppLocalMssql {

--- a/src/test/java/com/ozius/internship/project/TestDataCreator.java
+++ b/src/test/java/com/ozius/internship/project/TestDataCreator.java
@@ -8,6 +8,7 @@ import com.ozius.internship.project.entity.seller.Review;
 import com.ozius.internship.project.entity.seller.Seller;
 import com.ozius.internship.project.entity.seller.SellerType;
 import jakarta.persistence.EntityManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class TestDataCreator {
 
@@ -17,9 +18,9 @@ public class TestDataCreator {
         createProductsBaseData(em);
     }
 
-    public static void createBaseDataForReview(EntityManager em) {
+    public static void createBaseDataForReview(EntityManager em, PasswordEncoder passwordEncoder) {
         createBaseDataForProduct(em);
-        createBuyerBaseData(em);
+        createBuyerBaseData(em, passwordEncoder);
     }
 
     public static Buyer createBuyer(EntityManager em, UserAccount account){
@@ -29,22 +30,33 @@ public class TestDataCreator {
         return buyer;
     }
 
-    public static void createBuyerBaseData(EntityManager em){
-        Buyers.buyer2 = createBuyer(em,
-                new UserAccount(
-                        "Cosmina",
-                        "Maria",
-                        "cosminamaria@gmail.com",
-                        "/src/image2",
-                        "0735897635"));
+    public static void createBuyerBaseData(EntityManager em, PasswordEncoder passwordEncoder){
+        UserAccount account1 = new UserAccount(
+                "Cosmina",
+                "Maria",
+                "cosminamaria@gmail.com",
+                "/src/image2",
+                "0735897635");
+        account1.setInitialPassword(passwordEncoder.encode("Ozius1234!"));
+        Buyers.buyer1 = createBuyer(em, account1);
 
-        Buyers.buyer1 = createBuyer(em,
-                new UserAccount(
-                        "Marcel",
-                        "Danila",
-                        "marceldanila@gmail.com",
-                        "/src/image90",
-                        "0777777635"));
+        UserAccount account2 = new UserAccount(
+                "Marcel",
+                "Danila",
+                "marceldanila@gmail.com",
+                "/src/image90",
+                "0777777635");
+        account2.setInitialPassword(passwordEncoder.encode("Ozius1234!"));
+        Buyers.buyer2 = createBuyer(em, account2);
+
+        UserAccount account3 = new UserAccount(
+                "Vlad",
+                "Ciobotariu",
+                "vladciobotariu@gmail.com",
+                "none",
+                "+40770157915");
+        account3.setInitialPassword(passwordEncoder.encode("Ozius1234!"));
+        createBuyer(em, account3);
 
     }
 
@@ -72,7 +84,7 @@ public class TestDataCreator {
                         "303413"),
                 new UserAccount("Vlad",
                         "Ciobotariu",
-                        "vladciobotariu@gmail.com",
+                        "vladciobotariu1@gmail.com",
                         "/src/image1",
                         "0734896512"),
                 "Mega Fresh SRL"
@@ -103,8 +115,10 @@ public class TestDataCreator {
 
     public static void createCategoriesBaseData(EntityManager em){
 
-        Categories.category2 = createCategory(em, "Cereale", "image09");
-        Categories.category1 = createCategory(em, "Fructe", "image0008");
+        Categories.category2 = createCategory(em, "Fruits", "/images/fruits.svg");
+        Categories.category1 = createCategory(em, "Vegetables", "/images/vegetables.svg");
+
+        createCategory(em, "Dairy", "/images/dairy.svg");
     }
 
     public static Product createProduct(EntityManager em, String name, String description, String image, float price, Category category , Seller seller){

--- a/src/test/java/com/ozius/internship/project/TestDataCreator.java
+++ b/src/test/java/com/ozius/internship/project/TestDataCreator.java
@@ -12,14 +12,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class TestDataCreator {
 
-    public static void createBaseDataForProduct(EntityManager em) {
+    public static void createBaseDataForProduct(EntityManager em, PasswordEncoder passwordEncoder) {
         createCategoriesBaseData(em);
-        createSellerBaseData(em);
+        createSellerBaseData(em, passwordEncoder);
         createProductsBaseData(em);
     }
 
     public static void createBaseDataForReview(EntityManager em, PasswordEncoder passwordEncoder) {
-        createBaseDataForProduct(em);
+        createBaseDataForProduct(em, passwordEncoder);
         createBuyerBaseData(em, passwordEncoder);
     }
 
@@ -74,34 +74,39 @@ public class TestDataCreator {
         return seller;
     }
 
-    public static void  createSellerBaseData(EntityManager em){
-        Sellers.seller2 = createSellerFarmer(em,
+    public static void  createSellerBaseData(EntityManager em, PasswordEncoder passwordEncoder){
+
+        UserAccount account1 = new UserAccount("Vlad",
+                "Ciobotariu",
+                "vladciobotariu1@gmail.com",
+                "/src/image1",
+                "0734896512");
+        account1.setInitialPassword(passwordEncoder.encode("Ozius1234!"));
+        Sellers.seller1 = createSellerFarmer(em,
                 new Address("Romania",
                         "Timis",
                         "Timisoara",
                         "Strada Circumvalatiunii nr 4",
                         "Bloc 3 Scara B Ap 12",
                         "303413"),
-                new UserAccount("Vlad",
-                        "Ciobotariu",
-                        "vladciobotariu1@gmail.com",
-                        "/src/image1",
-                        "0734896512"),
+                account1,
                 "Mega Fresh SRL"
         );
 
-        Sellers.seller1 = createSellerFarmer(em,
+        UserAccount account2 = new UserAccount("Mihnea",
+                "Mondialu",
+                "mihneamondialu@gmail.com",
+                "/src/image99",
+                "0734896777");
+        account2.setInitialPassword(passwordEncoder.encode("Ozius1234!"));
+        Sellers.seller2 = createSellerFarmer(em,
                 new Address("Spania",
                         "Granada",
                         "Barcelona",
                         "Strada Real Madrid nr 4",
                         "Bloc Cupa Romaniei",
                         "307773"),
-                new UserAccount("Mihnea",
-                        "Mondialu",
-                        "mihneamondialu@gmail.com",
-                        "/src/image99",
-                        "0734896777"),
+                account2,
                 "FC BARCELONA"
         );
 

--- a/src/test/java/com/ozius/internship/project/TestDataSeed.java
+++ b/src/test/java/com/ozius/internship/project/TestDataSeed.java
@@ -1,12 +1,15 @@
 package com.ozius.internship.project;
 
+import com.ozius.internship.project.entity.UserAccount;
+import com.ozius.internship.project.entity.buyer.Buyer;
+import com.ozius.internship.project.infra.JpaHelper;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnit;
 import jakarta.transaction.Transactional;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,18 +19,23 @@ public class TestDataSeed {
     @PersistenceUnit
     private EntityManagerFactory emf;
 
-    @PostConstruct
-    @Transactional
-    public void createTestData(){
-        EntityManager em = emf.createEntityManager();
-        em.getTransaction().begin();
+    private final PasswordEncoder passwordEncoder;
 
-        TestDataCreator.createBuyerBaseData(em);
-        TestDataCreator.createSellerBaseData(em);
-        TestDataCreator.createCategoriesBaseData(em);
-        TestDataCreator.createProductsBaseData(em);
-
-        em.getTransaction().commit();
-        em.close();
+    public TestDataSeed(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
     }
+
+    @PostConstruct
+    public void createTestData(){
+
+        new JpaHelper(emf).doTransaction(em -> {
+
+            TestDataCreator.createBuyerBaseData(em, passwordEncoder);
+            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createCategoriesBaseData(em);
+            TestDataCreator.createProductsBaseData(em);
+
+        });
+    }
+
 }

--- a/src/test/java/com/ozius/internship/project/TestDataSeed.java
+++ b/src/test/java/com/ozius/internship/project/TestDataSeed.java
@@ -27,7 +27,7 @@ public class TestDataSeed {
         new JpaHelper(emf).doTransaction(em -> {
 
             TestDataCreator.createBuyerBaseData(em, passwordEncoder);
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             TestDataCreator.createProductsBaseData(em);
 

--- a/src/test/java/com/ozius/internship/project/TestDataSeed.java
+++ b/src/test/java/com/ozius/internship/project/TestDataSeed.java
@@ -1,13 +1,9 @@
 package com.ozius.internship.project;
 
-import com.ozius.internship.project.entity.UserAccount;
-import com.ozius.internship.project.entity.buyer.Buyer;
 import com.ozius.internship.project.infra.JpaHelper;
 import jakarta.annotation.PostConstruct;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceUnit;
-import jakarta.transaction.Transactional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;

--- a/src/test/java/com/ozius/internship/project/entity/BuyerEntityTests.java
+++ b/src/test/java/com/ozius/internship/project/entity/BuyerEntityTests.java
@@ -216,7 +216,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Buyer buyer = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             Product product = TestDataCreator.createProduct(em, "orez", "pentru fiert", "src/image4", 12f, category1, seller1);
 
@@ -279,7 +279,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Buyer buyer = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             TestDataCreator.createProductsBaseData(em);
 
@@ -312,7 +312,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Product productToAdd = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             Product product = TestDataCreator.createProduct(em, "orez", "pentru fiert", "src/image4", 12f, category1, seller1);
 
@@ -347,7 +347,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Product productToAdd = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             Product product = TestDataCreator.createProduct(em, "orez", "pentru fiert", "src/image4", 12f, category1, seller1);
 
@@ -376,7 +376,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Product productToRemove = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
             Product product = TestDataCreator.createProduct(em, "orez", "pentru fiert", "src/image4", 12f, category1, seller1);
 
@@ -407,7 +407,7 @@ public class BuyerEntityTests extends EntityBaseTest{
 
         //----Arrange
         Product productToRemove = doTransaction(em -> {
-            TestDataCreator.createSellerBaseData(em);
+            TestDataCreator.createSellerBaseData(em, passwordEncoder);
             TestDataCreator.createCategoriesBaseData(em);
 
             Product product1 = TestDataCreator.createProduct(em, "orez", "pentru fiert", "src/image4", 12f, category1, seller1);

--- a/src/test/java/com/ozius/internship/project/entity/CartEntityTest.java
+++ b/src/test/java/com/ozius/internship/project/entity/CartEntityTest.java
@@ -7,6 +7,8 @@ import com.ozius.internship.project.entity.exception.IllegalQuantityException;
 import com.ozius.internship.project.entity.exception.NotFoundException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Set;
 
@@ -22,9 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CartEntityTest extends EntityBaseTest {
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @Override
     public void createTestData(EntityManager em) {
-        createBaseDataForProduct(em);
+        createBaseDataForProduct(em, passwordEncoder);
     }
 
     @Test

--- a/src/test/java/com/ozius/internship/project/entity/EntityBaseTest.java
+++ b/src/test/java/com/ozius/internship/project/entity/EntityBaseTest.java
@@ -32,14 +32,11 @@ public class EntityBaseTest {
 
         entityFinder = new EntityFinder(emb);
 
-        doTransaction(em -> {
-            createTestData(em);
-        });
+        doTransaction(this::createTestData);
     }
 
     @AfterEach
     void tearDown() {
-
         emb.close();
     }
 
@@ -48,20 +45,14 @@ public class EntityBaseTest {
     }
 
     public void doTransaction(JpaCallbackVoid callback){
-        new JpaHelper(emf).doTransaction(em -> {
-            callback.execute(em);
-        });
+        new JpaHelper(emf).doTransaction(callback);
     }
 
     public void doManaged(JpaCallbackVoid callback){
-        new JpaHelper(emf).doManaged(em -> {
-            callback.execute(em);
-        });
+        new JpaHelper(emf).doManaged(callback);
     }
 
     public <T> T doTransaction(JpaCallback<T> callback){
-        return new JpaHelper(emf).doTransaction(em -> {
-            return callback.execute(em);
-        });
+        return new JpaHelper(emf).doTransaction(callback);
     }
 }

--- a/src/test/java/com/ozius/internship/project/entity/OrderEntityTests.java
+++ b/src/test/java/com/ozius/internship/project/entity/OrderEntityTests.java
@@ -37,7 +37,7 @@ public class OrderEntityTests extends EntityBaseTest{
     public void createTestData(EntityManager em) {
         //----Arrange
         TestDataCreator.createBuyerBaseData(em, passwordEncoder);
-        TestDataCreator.createSellerBaseData(em);
+        TestDataCreator.createSellerBaseData(em, passwordEncoder);
         TestDataCreator.createCategoriesBaseData(em);
 
         this.orderRepository = new SimpleJpaRepository<>(Order.class, emb);

--- a/src/test/java/com/ozius/internship/project/entity/OrderEntityTests.java
+++ b/src/test/java/com/ozius/internship/project/entity/OrderEntityTests.java
@@ -10,8 +10,10 @@ import com.ozius.internship.project.entity.order.OrderStatus;
 import com.ozius.internship.project.entity.seller.Seller;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -28,11 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OrderEntityTests extends EntityBaseTest{
 
     private JpaRepository<Order, Long> orderRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Override
     public void createTestData(EntityManager em) {
         //----Arrange
-        TestDataCreator.createBuyerBaseData(em);
+        TestDataCreator.createBuyerBaseData(em, passwordEncoder);
         TestDataCreator.createSellerBaseData(em);
         TestDataCreator.createCategoriesBaseData(em);
 

--- a/src/test/java/com/ozius/internship/project/entity/ProductEntityTest.java
+++ b/src/test/java/com/ozius/internship/project/entity/ProductEntityTest.java
@@ -6,6 +6,8 @@ import com.ozius.internship.project.entity.exception.IllegalPriceException;
 import com.ozius.internship.project.entity.seller.Seller;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.ozius.internship.project.TestDataCreator.Categories.category1;
 import static com.ozius.internship.project.TestDataCreator.Sellers.seller2;
@@ -15,10 +17,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProductEntityTest extends EntityBaseTest {
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @Override
     public void createTestData(EntityManager em) {
         TestDataCreator.createCategoriesBaseData(em);
-        TestDataCreator.createSellerBaseData(em);
+        TestDataCreator.createSellerBaseData(em, passwordEncoder);
     }
 
     @Test

--- a/src/test/java/com/ozius/internship/project/entity/seller/SellerEntityTests.java
+++ b/src/test/java/com/ozius/internship/project/entity/seller/SellerEntityTests.java
@@ -25,7 +25,6 @@ public class SellerEntityTests extends EntityBaseTest {
 
     private JpaRepository<Seller, Long> sellerRepository;
 
-    //TODO ask if autowired is good?
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -182,11 +181,11 @@ public class SellerEntityTests extends EntityBaseTest {
         //----Arrange
         Seller sellerToAdd = doTransaction(em -> {
             Address addressSeller = new Address("Romania", "Timis", "Timisoara", "Strada Circumvalatiunii nr 4", "Bloc 3 Scara B Ap 12", "303413");
-            UserAccount userAccount = new UserAccount("Vlad", "Ciobotariu", "vladciobotariu@gmail.com", "/src/image1", "0734896512");
+            UserAccount userAccount = new UserAccount("Vlad", "Ciobotariu", "vladciobotariu1@gmail.com", "/src/image1", "0734896512");
 
             Seller seller = TestDataCreator.createSellerCompany(em, addressSeller, userAccount, "bio", SellerType.PFA, new LegalDetails("MEGA FRESH SA", "RO37745609", new RegistrationNumber(CompanyType.F, 41, 34, LocalDate.now())));
 
-            TestDataCreator.createBuyerBaseData(em);
+            TestDataCreator.createBuyerBaseData(em, passwordEncoder);
             Address addressBuyer = new Address("Romania", "Timis", "Timisoara", "Strada Macilor 10", "Bloc 4, Scara F, ap 50", "300091");
 
             TestDataCreator.createOrder(em,addressBuyer, buyer1, seller);

--- a/src/test/java/com/ozius/internship/project/entity/seller/SellerReviewEntityTests.java
+++ b/src/test/java/com/ozius/internship/project/entity/seller/SellerReviewEntityTests.java
@@ -8,6 +8,8 @@ import com.ozius.internship.project.entity.exception.IllegalItemException;
 import com.ozius.internship.project.entity.exception.IllegalRatingException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.ozius.internship.project.TestDataCreator.Products.product1;
 import static com.ozius.internship.project.TestDataCreator.Buyers.buyer1;
@@ -19,9 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SellerReviewEntityTests extends EntityBaseTest {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @Override
     public void createTestData(EntityManager em) {
-        TestDataCreator.createBaseDataForReview(em);
+        TestDataCreator.createBaseDataForReview(em, passwordEncoder);
     }
 
     @Test


### PR DESCRIPTION
I modified createBuyer and createSeller base data so that now, i will inject the password encoder into them to encode the given passwords, please see how to add password. Till now, through test data creator we were creating accounts with null passwords in the database and we could not enter the accounts, now any account would have "Ozius1234!" password, i changed some classes to keep up with the change and every test passes, i just needed to autowire a password encoder into ____EntityTests (any entity test that uses createSellersBaseData or createBuyerBaseData), for now we should only use buyer accounts to log in because it is only a client side front end application, i will change to using queries on the database to see if the account is really a seller or a buyer and validate the email on login but for now it is not necessary. 

Thank you!